### PR TITLE
POD documentation - modified SEE ALSO section.

### DIFF
--- a/lib/Filter/CommaEquals.pm
+++ b/lib/Filter/CommaEquals.pm
@@ -77,14 +77,24 @@ I realized writing ,= is faster (by 3 key presses) than push. Also, I'm lazy.
 
 You can also look for additional information at:
 
-=for :list
-* L<GitHub|https://github.com/gryphonshafer/Filter-CommaEquals>
-* L<CPAN|http://search.cpan.org/dist/Filter-CommaEquals>
-* L<MetaCPAN|https://metacpan.org/pod/Filter::CommaEquals>
-* L<AnnoCPAN|http://annocpan.org/dist/Filter-CommaEquals>
-* L<Travis CI|https://travis-ci.org/gryphonshafer/Filter-CommaEquals>
-* L<Coveralls|https://coveralls.io/r/gryphonshafer/Filter-CommaEquals>
-* L<CPANTS|http://cpants.cpanauthors.org/dist/Filter-CommaEquals>
-* L<CPAN Testers|http://www.cpantesters.org/distro/F/Filter-CommaEquals.html>
+=over 
+
+=item * L<GitHub|https://github.com/gryphonshafer/Filter-CommaEquals>
+
+=item * L<CPAN|http://search.cpan.org/dist/Filter-CommaEquals>
+
+=item * L<MetaCPAN|https://metacpan.org/pod/Filter::CommaEquals>
+
+=item * L<AnnoCPAN|http://annocpan.org/dist/Filter-CommaEquals>
+
+=item * L<Travis CI|https://travis-ci.org/gryphonshafer/Filter-CommaEquals>
+
+=item * L<Coveralls|https://coveralls.io/r/gryphonshafer/Filter-CommaEquals>
+
+=item * L<CPANTS|http://cpants.cpanauthors.org/dist/Filter-CommaEquals>
+
+=item * L<CPAN Testers|http://www.cpantesters.org/distro/F/Filter-CommaEquals.html>
+
+=back
 
 =cut


### PR DESCRIPTION
The SEE ALSO section contained a list of URLs that weren't being displayed on
an Ubuntu 14.04, perl version 5.18.2 using the command line perldoc
CommaEquals.pm.
Replaced the =for :list command with an =over, =item *, =back set to get the
URLs displaying.
Irritating: Cannot achieve list of URLs one per line without a new line between
each one.